### PR TITLE
Allow JobItem and Jobs to have multiple materials

### DIFF
--- a/api/prisma/migrations/20250217163234_add_secondary_material_and_secondary_material_qty_to_job_job_item/migration.sql
+++ b/api/prisma/migrations/20250217163234_add_secondary_material_and_secondary_material_qty_to_job_job_item/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN     "materialQty" DOUBLE PRECISION,
+ADD COLUMN     "secondaryMaterialQty" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "JobItem" ADD COLUMN     "secondaryMaterialId" TEXT,
+ADD COLUMN     "secondaryMaterialQty" DOUBLE PRECISION;
+
+-- AddForeignKey
+ALTER TABLE "JobItem" ADD CONSTRAINT "JobItem_secondaryMaterialId_fkey" FOREIGN KEY ("secondaryMaterialId") REFERENCES "Material"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -164,7 +164,8 @@ model Material {
   additionalCostItems AdditionalCostLineItem[]
   jobs                Job[]                    @relation("Job::primaryMaterial")
   jobsSecondary       Job[]                    @relation("Job::secondaryMaterial")
-  jobItems            JobItem[]
+  jobItems            JobItem[]                @relation("JobItem::primaryMaterial")
+  jobItemsSecondary   JobItem[]                @relation("JobItem::secondaryMaterial")
   resourceType        ResourceType             @relation(fields: [resourceTypeId], references: [id])
   shop                Shop                     @relation(fields: [shopId], references: [id])
   images              MaterialImage[]
@@ -228,6 +229,7 @@ model Job {
   shopId                 String
   userId                 String
   materialId             String?
+  materialQty            Float?
   resourceTypeId         String?
   resourceId             String?
   groupId                String?
@@ -238,6 +240,7 @@ model Job {
   additionalCostOverride Boolean                  @default(false)
   status                 ProgressStatus           @default(NOT_STARTED)
   secondaryMaterialId    String?
+  secondaryMaterialQty   Float?
   additionalCosts        AdditionalCostLineItem[]
   group                  BillingGroup?            @relation(fields: [groupId], references: [id])
   material               Material?                @relation("Job::primaryMaterial", fields: [materialId], references: [id])
@@ -301,41 +304,44 @@ model AdditionalCostLineItem {
 }
 
 model JobItem {
-  id                String         @id @default(cuid())
-  title             String
-  status            ProgressStatus @default(NOT_STARTED)
-  qty               Float?
-  fileKey           String
-  fileUrl           String
-  fileName          String
-  fileType          String
-  fileThumbnailKey  String?
-  fileThumbnailUrl  String?
-  fileThumbnailName String?
-  stlVolume         Float?
-  stlBoundingBoxX   Float?
-  stlBoundingBoxY   Float?
-  stlBoundingBoxZ   Float?
-  stlIsWatertight   Boolean?
-  resourceId        String?
-  resourceTypeId    String?
-  materialId        String?
-  userId            String?
-  approved          Boolean?
-  createdAt         DateTime       @default(now())
-  updatedAt         DateTime       @updatedAt
-  active            Boolean        @default(true)
-  processingTimeQty Float?
-  timeQty           Float?
-  unitQty           Float?
-  materialQty       Float?
-  jobId             String
-  job               Job            @relation(fields: [jobId], references: [id], onDelete: Cascade)
-  material          Material?      @relation(fields: [materialId], references: [id])
-  resource          Resource?      @relation(fields: [resourceId], references: [id])
-  resourceType      ResourceType?  @relation(fields: [resourceTypeId], references: [id])
-  user              user?          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  logs              logs[]
+  id                   String         @id @default(cuid())
+  title                String
+  status               ProgressStatus @default(NOT_STARTED)
+  qty                  Float?
+  fileKey              String
+  fileUrl              String
+  fileName             String
+  fileType             String
+  fileThumbnailKey     String?
+  fileThumbnailUrl     String?
+  fileThumbnailName    String?
+  stlVolume            Float?
+  stlBoundingBoxX      Float?
+  stlBoundingBoxY      Float?
+  stlBoundingBoxZ      Float?
+  stlIsWatertight      Boolean?
+  resourceId           String?
+  resourceTypeId       String?
+  materialId           String?
+  secondaryMaterialId  String?
+  userId               String?
+  approved             Boolean?
+  createdAt            DateTime       @default(now())
+  updatedAt            DateTime       @updatedAt
+  active               Boolean        @default(true)
+  processingTimeQty    Float?
+  timeQty              Float?
+  unitQty              Float?
+  materialQty          Float?
+  secondaryMaterialQty Float?
+  jobId                String
+  job                  Job            @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  material             Material?      @relation("JobItem::primaryMaterial", fields: [materialId], references: [id])
+  secondaryMaterial    Material?      @relation("JobItem::secondaryMaterial", fields: [secondaryMaterialId], references: [id])
+  resource             Resource?      @relation(fields: [resourceId], references: [id])
+  resourceType         ResourceType?  @relation(fields: [resourceTypeId], references: [id])
+  user                 user?          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  logs                 logs[]
 }
 
 model BillingGroup {
@@ -491,9 +497,9 @@ enum UserBillingGroupRole {
 }
 
 model Navigation {
-  id String @id @default(cuid())
+  id     String @id @default(cuid())
   userId String
-  user user @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user   user   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   url String
 

--- a/app/src/components/jobitem/JobItem.jsx
+++ b/app/src/components/jobitem/JobItem.jsx
@@ -325,6 +325,17 @@ export const JobItem = ({
                           resourceTypeId={item.resourceTypeId}
                           opLoading={opLoading}
                           includeNone={true}
+                          materialType={"Primary"}
+                        />
+                        <MaterialPicker
+                          value={item.secondaryMaterialId}
+                          onChange={(value) =>
+                            updateJobItem({ secondaryMaterialId: value })
+                          }
+                          resourceTypeId={item.resourceTypeId}
+                          opLoading={opLoading}
+                          includeNone={true}
+                          materialType={"Secondary"}
                         />
                         {userIsPrivileged ? (
                           <ResourcePicker

--- a/app/src/components/materialPicker/MaterialPicker.jsx
+++ b/app/src/components/materialPicker/MaterialPicker.jsx
@@ -10,6 +10,7 @@ export const MaterialPicker = ({
   resourceTypeId,
   opLoading,
   includeNone,
+  materialType
 }) => {
   const { shopId } = useParams();
   const { materials, loading } = useMaterials(shopId, resourceTypeId);
@@ -34,7 +35,7 @@ export const MaterialPicker = ({
             : null,
         ].filter((v) => v)}
         prompt="Select Material"
-        label={"Material"}
+        label={`${materialType} Material`}
       />
     </Util.Col>
   );

--- a/app/src/routes/shops/[shopId]/jobs/[jobId]/index.jsx
+++ b/app/src/routes/shops/[shopId]/jobs/[jobId]/index.jsx
@@ -221,6 +221,17 @@ export const JobPage = () => {
                       resourceTypeId={job.resourceTypeId}
                       opLoading={opLoading}
                       includeNone={true}
+                      materialType={"Primary"}
+                    />
+                    <MaterialPicker
+                      value={job.secondaryMaterialId}
+                      onChange={(value) => {
+                        updateJob({ secondaryMaterialId: value });
+                      }}
+                      resourceTypeId={job.resourceTypeId}
+                      opLoading={opLoading}
+                      includeNone={true}
+                      materialType={"Secondary"}
                     />
                     {userIsPrivileged ? (
                       <ResourcePicker


### PR DESCRIPTION
Fixes #5 

What was changed: 

- Added secondaryMaterials and secondaryMaterialsQty field to job and jobItem tables.
- Updated UI to allow for selection of secondaryMaterials through items. 

Why was it changed: 

- The database was updated to support secondaryMaterials in the app and tracking them via. a prisma database.
- The UI was updated to support selection of secondaryMaterials to allow users to have a greater ability to buy according to their specific needs with the store.

How was it changed: 

- Changed prisma.schema and ran npx commands to update schema for prisma.
- Edited all .jsx files related to the selection and cost of materials and secondary materials specifically an index.jsx, MaterialPicker.jsx, JobItem.jsx, 

_Note: I'm meeting with Jack to discuss some clarifications and some confusion regarding the codebase and my issue prior to our Friday meeting. This PR will need to be updated (both in regards to current issues and cost metrics) prior to being merged._