### PR TITLE
Adding Email Notifications 

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -118,17 +118,19 @@ passport.use(
           },
         });
 
-        console.log("Email sent!");
-
+        console.log("Email Sent! - mock");
+        
         /*
+
         client.sendEmail({
-          "From": "slu-open-project@jackcrane.rocks", 
-          "To": `${req.user.email}`,
+          "From": `${process.env.POSTMARK_FROM_EMAIL}`, 
+          "To": `${user.email}`,
           "Subject": "User Login detected for OpenSLU",
-          "HtmlBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip ${req.ip}.` , 
-          "TextBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip ${req.ip}.`,
+          "HtmlBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip TODO.` , 
+          "TextBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip TODO.`,
           "MessageStream": "outbound"
         });
+        
         */
       }
 

--- a/api/index.js
+++ b/api/index.js
@@ -14,6 +14,7 @@ import { uploadRouter } from "./config/uploadthing.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import registerRoutes from "./util/router.js";
+import client from "#postmark";
 
 // Define __dirname for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -116,6 +117,19 @@ passport.use(
             type: LogType.USER_LOGIN,
           },
         });
+
+        console.log("Email sent!");
+
+        /*
+        client.sendEmail({
+          "From": "slu-open-project@jackcrane.rocks", 
+          "To": `${req.user.email}`,
+          "Subject": "User Login detected for OpenSLU",
+          "HtmlBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip ${req.ip}.` , 
+          "TextBody": `A login was detected at ${new Date(Date.now()).toLocaleString()} and ip ${req.ip}.`,
+          "MessageStream": "outbound"
+        });
+        */
       }
 
       // Pass the user to the next middleware

--- a/api/index.js
+++ b/api/index.js
@@ -14,7 +14,7 @@ import { uploadRouter } from "./config/uploadthing.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import registerRoutes from "./util/router.js";
-import client from "#postmark";
+// import client from "#postmark";
 
 // Define __dirname for ES modules
 const __filename = fileURLToPath(import.meta.url);

--- a/api/package.json
+++ b/api/package.json
@@ -34,6 +34,7 @@
     "passport": "^0.7.0",
     "passport-saml": "^3.2.4",
     "path": "^0.12.7",
+    "postmark": "^4.0.5",
     "prisma-docs-generator": "^0.8.0",
     "puppeteer": "^23.6.1",
     "uploadthing": "^7.2.0",
@@ -53,6 +54,7 @@
   },
   "imports": {
     "#prisma": "./util/prisma.js",
+    "#postmark": "./util/postmark.js",
     "#verifyAuth": "./util/verifyAuth.js",
     "#mock-prisma": "./util/__mocks__/prisma.js",
     "#gt": "./util/tests/generateToken.js",

--- a/api/routes/shop/[shopId]/job/[jobId]/comments/index.js
+++ b/api/routes/shop/[shopId]/job/[jobId]/comments/index.js
@@ -1,5 +1,6 @@
 import { prisma } from "#prisma";
 import { verifyAuth } from "#verifyAuth";
+// import client from "#postmark";
 
 export const get = [
   verifyAuth,
@@ -96,6 +97,59 @@ export const post = [
         jobId,
       },
     });
+
+    console.log("Email Sent! - mock");
+
+    /* - When you uncomment this don't forget to remove the comment for importing postmark!!!
+
+    const { name: shopName } = await prisma.shop.findFirst({
+        where: {
+          id: shopId,
+        }
+      });
+
+    const operators = await prisma.userShop.findMany({
+      where: {
+        shopId: shopId,
+        accountType: 'OPERATOR',
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+          },
+        },
+      },
+    });
+    
+    let emails = [];
+    for (const operator of operators) {
+      const jobLog = await prisma.logs.findFirst({
+        where: {
+          shopId: shopId,
+          userId: operator.user.id,
+          jobId: jobId,
+        }
+      });
+
+      jobLog && emails.push(operator.user.email);
+    }
+
+    if (!emails.includes(req.user.email)) {
+      emails.push(req.user.email);
+    }
+
+    client.sendEmail({
+      "From": `${process.env.POSTMARK_FROM_EMAIL}`, 
+      "To": `${emails.join(',')}`,
+      "Subject": `Comment created on job ${job.title} and shop ${shopName}`,
+      "HtmlBody": `The comment "${message}" was created on the job ${job.title} and shop ${shopName}`, 
+      "TextBody": `The comment "${message}" was created on the job ${job.title} and shop ${shopName}`,
+      "MessageStream": "outbound"
+    }); 
+
+    */
 
     const comments = await prisma.jobComment.findMany({
       where: {

--- a/api/routes/shop/[shopId]/job/index.js
+++ b/api/routes/shop/[shopId]/job/index.js
@@ -158,10 +158,16 @@ export const post = [
         },
       });
 
-      console.log("Email sent!");
+      console.log("Email Sent! - mock");
 
-      /*
+      /* - When you uncomment this don't forget to remove the comment for importing postmark!!!
 
+      const { name: shopName } = await prisma.shop.findFirst({
+        where: {
+          id: shopId,
+        }
+      });
+      
       const adminsOperators = await prisma.userShop.findMany({
         where: {
           shopId: shopId,
@@ -170,22 +176,29 @@ export const post = [
           },
         },
         include: {
-          user: true,
+          user: {
+            select: {
+              email: true,
+            },
+          },
         },
       });
 
       let emails = [];
-      emails.push(userShop.email);
       adminsOperators.forEach((userShop) => {
         userShop.user.email && emails.push(userShop.user.email);
       });
 
+      if (!emails.includes(req.user.email)) {
+        emails.push(req.user.email);
+      }
+      
       client.sendEmail({
-        "From": "slu-open-project@jackcrane.rocks", 
+        "From": `${process.env.POSTMARK_FROM_EMAIL}`, 
         "To": `${emails.join(',')}`,
         "Subject": `A Job was Created on Your Shop`,
-        "HtmlBody": `A job was created on the ${userShop.accountTitle} shop.` , 
-        "TextBody": `A job was created on the ${userShop.accountTitle} shop.`,
+        "HtmlBody": `The job ${title} was created on the ${shopName} shop.` , 
+        "TextBody": `The job ${title} was created on the ${shopName} shop.`,
         "MessageStream": "outbound"
       });
 

--- a/api/routes/shop/[shopId]/job/index.js
+++ b/api/routes/shop/[shopId]/job/index.js
@@ -2,6 +2,7 @@ import { LogType } from "@prisma/client";
 import { prisma } from "../../../../util/prisma.js";
 import { verifyAuth } from "../../../../util/verifyAuth.js";
 import { calculateTotalCostOfJob } from "../../../../util/docgen/invoice.js";
+import client from "#postmark";
 
 export const post = [
   verifyAuth,
@@ -156,6 +157,39 @@ export const post = [
           }),
         },
       });
+
+      console.log("Email sent!");
+
+      /*
+
+      const adminsOperators = await prisma.userShop.findMany({
+        where: {
+          shopId: shopId,
+          accountType: {
+            in: ['ADMIN', 'OPERATOR'], 
+          },
+        },
+        include: {
+          user: true,
+        },
+      });
+
+      let emails = [];
+      emails.push(userShop.email);
+      adminsOperators.forEach((userShop) => {
+        userShop.user.email && emails.push(userShop.user.email);
+      });
+
+      client.sendEmail({
+        "From": "slu-open-project@jackcrane.rocks", 
+        "To": `${emails.join(',')}`,
+        "Subject": `A Job was Created on Your Shop`,
+        "HtmlBody": `A job was created on the ${userShop.accountTitle} shop.` , 
+        "TextBody": `A job was created on the ${userShop.accountTitle} shop.`,
+        "MessageStream": "outbound"
+      });
+
+      */
 
       if (billingGroupToCreateJobAs) {
         await prisma.logs.create({

--- a/api/routes/shop/[shopId]/job/index.js
+++ b/api/routes/shop/[shopId]/job/index.js
@@ -2,7 +2,7 @@ import { LogType } from "@prisma/client";
 import { prisma } from "../../../../util/prisma.js";
 import { verifyAuth } from "../../../../util/verifyAuth.js";
 import { calculateTotalCostOfJob } from "../../../../util/docgen/invoice.js";
-import client from "#postmark";
+// import client from "#postmark";
 
 export const post = [
   verifyAuth,

--- a/api/util/postmark.js
+++ b/api/util/postmark.js
@@ -1,0 +1,3 @@
+import postmark from "postmark"
+export const client = new postmark.ServerClient(process.env.POSTMARK_API_KEY); 
+export default client;

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1258,6 +1258,15 @@ axios@^1.6.2:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.4:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.1.tgz#7c118d2146e9ebac512b7d1128771cdd738d11e3"
+  integrity sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 b4a@^1.6.4:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.7.tgz#a99587d4ebbfbd5a6e3b21bdb5d5fa385767abe4"
@@ -4054,6 +4063,13 @@ postcss@^8.4.43:
     nanoid "^3.3.7"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postmark@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/postmark/-/postmark-4.0.5.tgz#515ae85562fcedbec6ae7eb0ef180dded1dbc05d"
+  integrity sha512-nerZdd3TwOH4CgGboZnlUM/q7oZk0EqpZgJL+Y3Nup8kHeaukxouQ6JcFF3EJEijc4QbuNv1TefGhboAKtf/SQ==
+  dependencies:
+    axios "^1.7.4"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Fixes #4 

What was changed: 

- Added dependencies and aliasing so for postmark emailing.
- Added email sending via. postmark for USER_LOGIN and JOB_CREATED logs. 

Why was it changed: 

- The dependencies were updated to allow postmark to be used within the program and aliasing was created so the path doesn't need to be specified to constantly use postmark in the future.
- Email sending was added so that costumers could be alerted of events going on with their account and jobs in open-project for security protection and protection of their jobs/shops.

How was it changed: 

- Changed yarn.lock via. yarn add postmark to allow postmark to be used within the app.
- Changed package.json to allow for aliasing and make using postmark easier throughout the app.
- Created postmark.js to ensure constant client connection via. postmark doesn't occur.
- Created email sending for USER_LOGIN and JOB_CREATED logs in the corresponding index.js files.

_General Note: The commented code I added for emails is the actual email code (please review)! I just wanted to ensure emails aren't sent since we have a limited number. Additionally, I didn't see any logs related to comment_created so I didn't create any email notifications for that and I don't see anything related to notification settings or unsubscribing implemented for emails already. I saw some comments in the sidenav code (within [page.jsx](https://github.com/oss-slu/open-project/blob/main/app/src/components/page/page.jsx)) related to adding related items to the sidenav but it wasn't yet implemented and so I held off on the footer for now. I will check-in about this via. our Friday meeting with our client or if it's cancelled because of break I will contact him separately._