### PR TITLE
Added button and POST request for creating a new shop

### DIFF
--- a/app/src/hooks/useShops.jsx
+++ b/app/src/hooks/useShops.jsx
@@ -90,6 +90,26 @@ export const useShops = () => {
     }
   };
 
+
+  const newShop = async (data) => {
+    try { 
+      const r = await authFetch(`/api/shop`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
+      const createdShop = await r.json();
+      if (createdShop.shop) {
+        setShops(createdShop.shops);
+      } else {
+        toast.error(createdShop);
+        setError(createdShop);
+      }
+    } catch (error) {
+      setError(error);
+    }
+  };
+
+
   useEffect(() => {
     fetchShops();
   }, []);
@@ -103,6 +123,7 @@ export const useShops = () => {
     addUserToShop,
     removeUserFromShop,
     changeUserRole,
+    newShop,
     opLoading,
   };
 };

--- a/app/src/routes/shops/index.jsx
+++ b/app/src/routes/shops/index.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import { useAuth } from "../../hooks/useAuth";
 import { useShops } from "../../hooks/useShops";
 import { Loading } from "../../components/loading/Loading";
-import { Typography } from "tabler-react-2";
+import { Typography , Util} from "tabler-react-2";
 import { ShopCard } from "../../components/shopcard/ShopCard";
 import { Page, sidenavItems } from "../../components/page/page";
+import { Button } from "tabler-react-2/dist/button";
+
+
 const { H1 } = Typography;
 
 export const Shops = () => {
@@ -14,8 +17,17 @@ export const Shops = () => {
   if (loading) return <Loading />;
 
   return (
-    <Page sidenavItems={sidenavItems("Shops", user.admin)}>
-      <H1>Shops</H1>
+    <Page sidenavItems={sidenavItems("Shops", user.admin)}
+    >
+      <Util.Row justify="between" align="center">
+        <H1>Shops</H1>
+        {user.admin &&(
+          <Button onClick={() => navigate("/app/shopId")}> {/*Implement UseState and connect to POST request implemented in UseShops*/}
+            New Shop
+          </Button>
+        )}
+      </Util.Row>
+      <Util.Spacer size={1} />
       {shops.map((shop) => (
         <ShopCard key={shop.id} shop={shop} />
       ))}


### PR DESCRIPTION
Fixes #23

What was changed:
Implemented a button that only admins can see, on shops main page in the front end to allow creation of new shops. 
Implemented a POST request in order to connect job creation. 

Why it was changed:
Adding a button the shop front end allows admins to create a new shop instance.
POST request needed to be added in order to connect front end inputs and generate a new shop.

How was it changed:
Added newShop() within useShops.jsx for POST request.
Used Util, and Button in order to correctly organize shop creation button.

