### PR TITLE
Changed paths in API to existing Aliases

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -6,7 +6,7 @@ import samlConfig from "./config/saml-config.js";
 import cors from "cors";
 import jwt from "jsonwebtoken";
 import dotenv from "dotenv";
-import { prisma } from "./util/prisma.js";
+import { prisma } from "#prisma";
 import { LogType } from "@prisma/client";
 dotenv.config();
 import { createRouteHandler } from "uploadthing/express";

--- a/api/routes/auth/me.js
+++ b/api/routes/auth/me.js
@@ -1,4 +1,4 @@
-import { verifyAuth } from "../../util/verifyAuth.js";
+import { verifyAuth } from "#verifyAuth";
 
 export const get = [
   verifyAuth,

--- a/api/routes/shop/[shopId]/index.js
+++ b/api/routes/shop/[shopId]/index.js
@@ -1,6 +1,6 @@
 import { LogType } from "@prisma/client";
-import { prisma } from "../../../util/prisma.js";
-import { verifyAuth } from "../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import { SHOP_SELECT } from "../shared.js";
 import { z } from "zod";
 

--- a/api/routes/shop/[shopId]/job/[jobId]/index.js
+++ b/api/routes/shop/[shopId]/job/[jobId]/index.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 import { LedgerItemType, LogType, Prisma } from "@prisma/client";
-import { prisma } from "../../../../../util/prisma.js";
-import { verifyAuth } from "../../../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import { generateInvoice } from "../../../../../util/docgen/invoice.js";
 import { z } from "zod";
 

--- a/api/routes/shop/[shopId]/job/index.js
+++ b/api/routes/shop/[shopId]/job/index.js
@@ -1,6 +1,6 @@
 import { LogType } from "@prisma/client";
-import { prisma } from "../../../../util/prisma.js";
-import { verifyAuth } from "../../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import { calculateTotalCostOfJob } from "../../../../util/docgen/invoice.js";
 // import client from "#postmark";
 

--- a/api/routes/shop/[shopId]/user/[userId]/index.js
+++ b/api/routes/shop/[shopId]/user/[userId]/index.js
@@ -1,6 +1,6 @@
 import { LedgerItemType, LogType } from "@prisma/client";
-import { prisma } from "../../../../../util/prisma.js";
-import { verifyAuth } from "../../../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import { calculateTotalCostOfJobByJobId } from "../../../../../util/docgen/invoice.js";
 
 export const get = [

--- a/api/routes/shop/index.js
+++ b/api/routes/shop/index.js
@@ -1,6 +1,6 @@
 import { LedgerItemType, LogType } from "@prisma/client";
-import { prisma } from "../../util/prisma.js";
-import { verifyAuth } from "../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import { SHOP_SELECT, SHOP_SELECT_WITH_LEDGER } from "./shared.js";
 
 export const get = [

--- a/api/routes/users/[userId]/admin.js
+++ b/api/routes/users/[userId]/admin.js
@@ -1,6 +1,6 @@
 import { LogType } from "@prisma/client";
-import { prisma } from "../../../util/prisma.js";
-import { verifyAuth } from "../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 
 // Promote a user to global admin
 export const post = [

--- a/api/routes/users/[userId]/index.js
+++ b/api/routes/users/[userId]/index.js
@@ -1,5 +1,5 @@
-import { prisma } from "../../../util/prisma.js";
-import { verifyAuth } from "../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 
 export const get = [
   verifyAuth,

--- a/api/routes/users/[userId]/suspension.js
+++ b/api/routes/users/[userId]/suspension.js
@@ -1,6 +1,6 @@
 import { LogType } from "@prisma/client";
-import { prisma } from "../../../util/prisma.js";
-import { verifyAuth } from "../../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 
 export const post = [
   verifyAuth,

--- a/api/routes/users/[userId]/tests/_admin.test.js
+++ b/api/routes/users/[userId]/tests/_admin.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import request from "supertest";
-import { app } from "../../../../index.js";
+import { app } from "#index";
 import { gt } from "#gt";
 import { prisma as mockPrisma } from "#mock-prisma";
 import { prisma } from "#prisma";

--- a/api/routes/users/[userId]/tests/_index.test.js
+++ b/api/routes/users/[userId]/tests/_index.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import request from "supertest";
-import { app } from "../../../../index.js";
+import { app } from "#index";
 import { gt } from "#gt";
 import { prisma } from "#prisma";
 import { AccountType, LogType } from "@prisma/client";

--- a/api/routes/users/[userId]/tests/_suspension.test.js
+++ b/api/routes/users/[userId]/tests/_suspension.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import request from "supertest";
-import { app } from "../../../../index.js";
+import { app } from "#index";
 import { gt } from "#gt";
 import { prisma } from "#prisma";
 import { prisma as mockPrisma } from "#mock-prisma";

--- a/api/routes/users/index.js
+++ b/api/routes/users/index.js
@@ -1,6 +1,6 @@
 import { LogType } from "@prisma/client";
-import { prisma } from "../../util/prisma.js";
-import { verifyAuth } from "../../util/verifyAuth.js";
+import { prisma } from "#prisma";
+import { verifyAuth } from "#verifyAuth";
 import fs from "fs";
 
 export const get = [

--- a/api/routes/users/tests/_user.test.js
+++ b/api/routes/users/tests/_user.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import request from "supertest";
-import { app } from "../../../index.js";
+import { app } from "#index";
 import { gt } from "#gt";
 import { prisma } from "#mock-prisma";
 import { prisma as realPrisma } from "#prisma";


### PR DESCRIPTION
**Opening new clean branch to git rid of commits associated my previous PR**

Fixes #22 

What was changed: The import file paths were replaced in file in the API folders with new aliases that have previously been set up.

Why was it changed: These changes were made to improve code readability and consistency across the codebase.

How was it changed: File path aliases have been set up in the package.json file.

These changes only existed in the API folder and I will have to set up new aliases for the file paths in the app folder.
