### PR TITLE
Promote users to group admins when they are affiliated with a group

### DIFF
--- a/api/routes/shop/[shopId]/groups/[groupId]/users/[userId].js
+++ b/api/routes/shop/[shopId]/groups/[groupId]/users/[userId].js
@@ -159,6 +159,34 @@ export const post = [
           },
         });
 
+        if (role === "ADMIN") {
+          const promotedAccounts = await prisma.userShop.updateMany({
+            where: {
+              userId,
+              shopId,
+              accountType: "CUSTOMER",
+            },
+            data: {
+              accountType: "GROUP_ADMIN",
+            },
+          });
+
+          if (promotedAccounts.count) {
+            await prisma.logs.create({
+              data: {
+                type: LogType.USER_SHOP_ROLE_CHANGED,
+                userId,
+                shopId,
+                billingGroupId: groupId,
+                userBillingGroupId: billingGroupUser.id,
+                message:
+                  "User promoted to group admin by billing group membership update",
+                to: JSON.stringify({ accountType: "GROUP_ADMIN" }),
+              },
+            });
+          }
+        }
+
         await prisma.logs.create({
           data: {
             type: LogType.USER_BILLING_GROUP_ROLE_CHANGED,
@@ -193,6 +221,34 @@ export const post = [
         role,
       },
     });
+
+    if (role === "ADMIN") {
+      const promotedAccounts = await prisma.userShop.updateMany({
+        where: {
+          userId,
+          shopId,
+          accountType: "CUSTOMER",
+        },
+        data: {
+          accountType: "GROUP_ADMIN",
+        },
+      });
+
+      if (promotedAccounts.count) {
+        await prisma.logs.create({
+          data: {
+            type: LogType.USER_SHOP_ROLE_CHANGED,
+            userId,
+            shopId,
+            billingGroupId: groupId,
+            userBillingGroupId: newUbg.id,
+            message:
+              "User promoted to group admin by billing group membership creation",
+            to: JSON.stringify({ accountType: "GROUP_ADMIN" }),
+          },
+        });
+      }
+    }
 
     await prisma.logs.create({
       data: {

--- a/api/routes/shop/[shopId]/groups/index.js
+++ b/api/routes/shop/[shopId]/groups/index.js
@@ -68,6 +68,30 @@ export const post = [
         },
       });
 
+      const promotedAccounts = await prisma.userShop.updateMany({
+        where: {
+          userId: userToConnect.userId,
+          shopId,
+          accountType: "CUSTOMER",
+        },
+        data: {
+          accountType: "GROUP_ADMIN",
+        },
+      });
+
+      if (promotedAccounts.count) {
+        await prisma.logs.create({
+          data: {
+            userId: userToConnect.userId,
+            shopId,
+            billingGroupId: group.id,
+            type: LogType.USER_SHOP_ROLE_CHANGED,
+            message: "User promoted to group admin by billing group creation",
+            to: JSON.stringify({ accountType: "GROUP_ADMIN" }),
+          },
+        });
+      }
+
       await prisma.logs.createMany({
         data: [
           {


### PR DESCRIPTION
This pull request introduces logic to automatically promote users from "CUSTOMER" to "GROUP_ADMIN" in the `userShop` table when they gain admin status in a billing group, ensuring role consistency across the system. It also logs these promotions for audit purposes.

**Role promotion and logging improvements:**

* When a user is made an "ADMIN" of a billing group, their `userShop` account type is updated from "CUSTOMER" to "GROUP_ADMIN" if necessary, both when updating an existing billing group membership and when creating a new one (`api/routes/shop/[shopId]/groups/[groupId]/users/[userId].js`). ([api/routes/shop/[shopId]/groups/[groupId]/users/[userId].jsR162-R189](diffhunk://#diff-bab6a52cc1fa57032b312381f6393a43817b030061a3e637927f366f801c649fR162-R189), [api/routes/shop/[shopId]/groups/[groupId]/users/[userId].jsR225-R252](diffhunk://#diff-bab6a52cc1fa57032b312381f6393a43817b030061a3e637927f366f801c649fR225-R252))
* When a user is connected to a billing group during group creation, their `userShop` account type is similarly promoted if applicable (`api/routes/shop/[shopId]/groups/index.js`). ([api/routes/shop/[shopId]/groups/index.jsR71-R94](diffhunk://#diff-da365f08b6312cac5bf9634685bb65633b8e885a43e50f02539f36ed4af32dccR71-R94))

**Audit logging enhancements:**

* Each promotion to "GROUP_ADMIN" is logged in the `logs` table with a clear message and relevant context for traceability (`api/routes/shop/[shopId]/groups/[groupId]/users/[userId].js`, `api/routes/shop/[shopId]/groups/index.js`). ([api/routes/shop/[shopId]/groups/[groupId]/users/[userId].jsR162-R189](diffhunk://#diff-bab6a52cc1fa57032b312381f6393a43817b030061a3e637927f366f801c649fR162-R189), [api/routes/shop/[shopId]/groups/[groupId]/users/[userId].jsR225-R252](diffhunk://#diff-bab6a52cc1fa57032b312381f6393a43817b030061a3e637927f366f801c649fR225-R252), [api/routes/shop/[shopId]/groups/index.jsR71-R94](diffhunk://#diff-da365f08b6312cac5bf9634685bb65633b8e885a43e50f02539f36ed4af32dccR71-R94))