### PR TITLE
Add default due date when creating jbos

### DIFF
--- a/api/routes/shop/[shopId]/job/index.js
+++ b/api/routes/shop/[shopId]/job/index.js
@@ -79,6 +79,14 @@ export const post = [
         billingGroupId,
       } = req.body;
 
+      const fallbackDueDate = new Date();
+      fallbackDueDate.setDate(fallbackDueDate.getDate() + 14);
+      fallbackDueDate.setHours(0, 0, 0, 0);
+      const dueDateToUse = dueDate ? new Date(dueDate) : fallbackDueDate;
+      const normalizedDueDate = Number.isNaN(dueDateToUse.getTime())
+        ? fallbackDueDate
+        : dueDateToUse;
+
       if (onBehalfOf) {
         if (
           userShop.accountType !== "ADMIN" &&
@@ -183,7 +191,7 @@ export const post = [
             shop: { connect: { id: shopId } },
             user: { connect: { id: userToCreateJobAs } },
             group: { connect: { id: billingGroupToCreateJobAs?.id } },
-            dueDate: new Date(dueDate),
+            dueDate: normalizedDueDate,
           },
         });
       } else {
@@ -193,7 +201,7 @@ export const post = [
             description,
             shop: { connect: { id: shopId } },
             user: { connect: { id: userToCreateJobAs } },
-            dueDate: new Date(dueDate),
+            dueDate: normalizedDueDate,
           },
         });
       }

--- a/api/routes/shop/[shopId]/job/tests/_index.test.js
+++ b/api/routes/shop/[shopId]/job/tests/_index.test.js
@@ -76,5 +76,30 @@ describe("/shop/[shopId]/job", () => {
             expect(res.body.error).toBe("Unauthorized")
             expect(createLogsSpy).not.toHaveBeenCalled();
         });
+
+        it("defaults due date to two weeks out when dueDate is not provided", async () => {
+            prisma.userShop.findFirst = findFirstSpy.mockResolvedValue({
+                userId: "example-id",
+                shopId: tc.shop.id,
+                active: true,
+            });
+
+            const expectedDueDate = new Date();
+            expectedDueDate.setDate(expectedDueDate.getDate() + 14);
+            expectedDueDate.setHours(0, 0, 0, 0);
+
+            const res = await request(app)
+                .post(`/api/shop/${tc.shop.id}/job`)
+                .set(...(await gt({ ga: true })))
+                .send({
+                    title: "Job with default due date",
+                    description: "Missing due date should be defaulted",
+                });
+
+            expect(res.status).toBe(200);
+            expect(new Date(res.body.job.dueDate).toISOString()).toBe(
+                expectedDueDate.toISOString(),
+            );
+        });
     })
 })

--- a/app/src/hooks/useJobs.jsx
+++ b/app/src/hooks/useJobs.jsx
@@ -9,6 +9,18 @@ import { useAuth } from "#useAuth";
 import { ShopUserPicker } from "#shopUserPicker";
 import { BillingGroupPicker } from "../components/billingGroupPicker/BillingGroupPicker";
 
+const toLocalDateInputValue = (date) => {
+  const localDate = new Date(date);
+  localDate.setMinutes(localDate.getMinutes() - localDate.getTimezoneOffset());
+  return localDate.toISOString().split("T")[0];
+};
+
+const getDefaultDueDate = () => {
+  const dueDate = new Date();
+  dueDate.setDate(dueDate.getDate() + 14);
+  return `${toLocalDateInputValue(dueDate)}T00:00:00`;
+};
+
 const CreateJobModalContent = ({
   onSubmit,
   defaultBillingGroupId = null,
@@ -16,7 +28,7 @@ const CreateJobModalContent = ({
 }) => {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [dueDate, setDueDate] = useState("");
+  const [dueDate, setDueDate] = useState(getDefaultDueDate);
   const [loading, setLoading] = useState(false);
   const [onBehalfOf, setOnBehalfOf] = useState(false);
   const [onBehalfOfUserId, setOnBehalfOfUserId] = useState(null);
@@ -226,7 +238,7 @@ export const useJobs = (shopId) => {
   const CreateSimpleSubPage = () => {
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
-    const [dueDate, setDueDate] = useState("");
+    const [dueDate, setDueDate] = useState(getDefaultDueDate);
     const [loading, setLoading] = useState(false);
     const [onBehalfOf] = useState(false);
     const [onBehalfOfUserId] = useState(null);


### PR DESCRIPTION
This pull request introduces a default due date for job creation, ensuring that if a due date isn't provided, it is automatically set to two weeks from the current date. This change improves both backend consistency and frontend user experience by preventing jobs from being created without a valid due date. The update also includes a test to verify this behavior and updates the frontend to pre-populate the due date input with the default value.

**Backend improvements:**

* Added logic in `api/routes/shop/[shopId]/job/index.js` to set a fallback due date to two weeks from the current date if none is provided, and normalized the due date to ensure validity. ([api/routes/shop/[shopId]/job/index.jsR82-R89](diffhunk://#diff-d9e94f625c9de761b6c915a46d781957eca1cc3a915f0b331b9ae10786788dc8R82-R89))
* Updated job creation to use the normalized due date for both admin and non-admin users, ensuring the default is applied consistently. ([api/routes/shop/[shopId]/job/index.jsL186-R194](diffhunk://#diff-d9e94f625c9de761b6c915a46d781957eca1cc3a915f0b331b9ae10786788dc8L186-R194), [api/routes/shop/[shopId]/job/index.jsL196-R204](diffhunk://#diff-d9e94f625c9de761b6c915a46d781957eca1cc3a915f0b331b9ae10786788dc8L196-R204))

**Testing enhancements:**

* Added a test in `api/routes/shop/[shopId]/job/tests/_index.test.js` to verify that the due date defaults to two weeks out when not provided. ([api/routes/shop/[shopId]/job/tests/_index.test.jsR79-R103](diffhunk://#diff-ae6608b5e41269554e6bd6a0bb62495211f0782a7d6da4c6bd80a7b4b0fd4754R79-R103))

**Frontend improvements:**

* Updated `app/src/hooks/useJobs.jsx` to pre-populate the due date input in job creation forms with the default value of two weeks from now. [[1]](diffhunk://#diff-7577c21e27d612c88ceb6b2d6d7f4ef97939296f220459f3e11b5e57cbc5d258R12-R31) [[2]](diffhunk://#diff-7577c21e27d612c88ceb6b2d6d7f4ef97939296f220459f3e11b5e57cbc5d258L229-R241)